### PR TITLE
ci: fix post-dependabot workflow failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     labels:
       - "area/backend"
       - "type/security"
+    ignore:
+      - dependency-name: "github.com/casbin/gorm-adapter/v3"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/mirror-template.yml
+++ b/.github/workflows/mirror-template.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: 'Mirror to gitee'
         uses: pixta-dev/repository-mirroring-action@v1
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,15 +9,16 @@ on:
     - cron: "21 20 * * 0"
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: read
-  id-token: write
-  security-events: write
+permissions: read-all
 
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/aigc/prompts/ci-dependabot-casbin-incident-2026-06-05.zh-CN.md
+++ b/aigc/prompts/ci-dependabot-casbin-incident-2026-06-05.zh-CN.md
@@ -1,0 +1,23 @@
+# 2026-06-05 mss-boot CI 失败复盘
+
+## 现象
+
+Dependabot 合并 `github.com/casbin/gorm-adapter/v3` 后，`main` 的 CI 和 govulncheck 编译失败。错误表现为 adapter 实现了 `casbin/v3/model.Model` 接口，但项目当前仍使用 `casbin/v2/persist.Adapter`。
+
+## 处理
+
+- 将 `github.com/casbin/gorm-adapter/v3` 固定回兼容 Casbin v2 的 `v3.38.0`。
+- 在 Dependabot 配置里忽略该依赖的自动 minor/patch 升级，避免再次隐式引入 Casbin v3 接口。
+- Scorecard 权限从 workflow 顶层收窄到 job 级别。
+- mirror 模板 checkout 改为 `fetch-depth: 0`。
+
+## 验证
+
+- `go test ./...`
+- `GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
+- `git diff --check`
+
+## 后续
+
+长期应评估是否整体迁移到 Casbin v3；迁移前不要让 adapter 自动升级到会改变接口 major 的版本。

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/smithy-go v1.24.3
 	github.com/bsm/redislock v0.9.4
 	github.com/casbin/casbin/v2 v2.135.0
-	github.com/casbin/gorm-adapter/v3 v3.41.0
+	github.com/casbin/gorm-adapter/v3 v3.38.0
 	github.com/casbin/mongodb-adapter/v3 v3.7.0
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/fsnotify/fsnotify v1.9.0
@@ -91,7 +91,6 @@ require (
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.1 // indirect
-	github.com/casbin/casbin/v3 v3.8.1 // indirect
 	github.com/casbin/govaluate v1.10.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,10 +118,8 @@ github.com/bytedance/sonic/loader v0.5.1 h1:Ygpfa9zwRCCKSlrp5bBP/b/Xzc3VxsAW+5NI
 github.com/bytedance/sonic/loader v0.5.1/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/casbin/casbin/v2 v2.135.0 h1:6BLkMQiGotYyS5yYeWgW19vxqugUlvHFkFiLnLR/bxk=
 github.com/casbin/casbin/v2 v2.135.0/go.mod h1:FmcfntdXLTcYXv/hxgNntcRPqAbwOG9xsism0yXT+18=
-github.com/casbin/casbin/v3 v3.8.1 h1:D4dEY4knePPR4YgNP5WZtWNaOxD0UK0LpPy9+zxtBwo=
-github.com/casbin/casbin/v3 v3.8.1/go.mod h1:5rJbQr2e6AuuDDNxnPc5lQlC9nIgg6nS1zYwKXhpHC8=
-github.com/casbin/gorm-adapter/v3 v3.41.0 h1:Xhpi0tfRP9aKPDWDf6dgBxHZ9UM6IophxxPIEGWqCNM=
-github.com/casbin/gorm-adapter/v3 v3.41.0/go.mod h1:BQZRJhwUnwMpI+pT2m7/cUJwXxrHfzpBpPcNTyMGeGA=
+github.com/casbin/gorm-adapter/v3 v3.38.0 h1:j+2YEQU0F4RmlXaVihVV82OTe268/oKI7QKeHRkbu84=
+github.com/casbin/gorm-adapter/v3 v3.38.0/go.mod h1:kjXoK8MqA3E/CcqEF2l3SCkhJj1YiHVR6SF0LMvJoH4=
 github.com/casbin/govaluate v1.3.0/go.mod h1:G/UnbIjZk/0uMNaLwZZmFQrR72tYRZWQkO70si/iR7A=
 github.com/casbin/govaluate v1.10.0 h1:ffGw51/hYH3w3rZcxO/KcaUIDOLP84w7nsidMVgaDG0=
 github.com/casbin/govaluate v1.10.0/go.mod h1:G/UnbIjZk/0uMNaLwZZmFQrR72tYRZWQkO70si/iR7A=


### PR DESCRIPTION
## Summary
- pin gorm-adapter to the Casbin v2-compatible release after Dependabot introduced a Casbin v3 adapter mismatch
- ignore automatic minor/patch updates for gorm-adapter until the Casbin major migration is handled intentionally
- fix mirror checkout depth and Scorecard permissions
- record the dependency incident in aigc memory

## Tests / 验证
- go test ./...
- GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@latest ./...
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- git diff --check

## Docs / 文档
- Added aigc/prompts/ci-dependabot-casbin-incident-2026-06-05.zh-CN.md

## Security / 安全
- govulncheck reports 0 vulnerabilities in called code paths.
- Scorecard write permissions are limited to the scorecard job.

## Release / 发布与回滚
- Fixes main branch CI after Dependabot merges. Rollback is reverting this PR, but that would reintroduce the Casbin adapter mismatch.