### PR TITLE
docs: add agent collaboration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS
+
+This repository is the core Go library for `mss-boot-io`. Agents should keep
+changes small, verifiable, and understandable to outside contributors.
+
+## Repository Role
+
+- `mss-boot`: shared Go framework and infrastructure primitives.
+- `mss-boot-admin`: admin backend built on top of this framework.
+- `mss-boot-admin-antd`: admin frontend.
+- `mss-boot-docs`: public documentation and organization-level AI memory.
+
+## Working Rules
+
+- Prefer existing package patterns over new abstractions.
+- Do not change public APIs, config formats, or persistence behavior without
+  updating docs or `aigc` memory.
+- Do not store prompts or decision notes in the repository root.
+- Put repository-local AI memory under `aigc/prompts/`.
+- Use lowercase kebab-case filenames; use `.zh-CN.md` for Chinese memory files.
+- Never commit secrets, private endpoints, tokens, or local credentials.
+
+## Validation
+
+Use the narrowest command that proves the change, then broaden when shared
+behavior is touched:
+
+- Go tests: `go test ./...`
+- Vulnerability scan: `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
+- Workflow lint: `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
+- Whitespace check: `git diff --check`
+
+## Pull Request Expectations
+
+Every PR should explain:
+
+- tests impact;
+- docs impact;
+- security impact;
+- release, compatibility, migration, or rollback impact.
+
+Workflow, deployment, API contract, config, migration, or security changes
+should include docs, README, changelog, or `aigc` memory updates.
+
+## Release And Compatibility
+
+- Keep Dependabot updates reviewable and reversible.
+- Do not allow dependency updates to silently change major interface families.
+- When a dependency touches auth, policy, storage, config, or transport layers,
+  document the compatibility and rollback path.

--- a/aigc/prompts/agents-guide-2026-06-05.zh-CN.md
+++ b/aigc/prompts/agents-guide-2026-06-05.zh-CN.md
@@ -1,0 +1,18 @@
+# 2026-06-05 AGENTS.md 落盘记忆
+
+## 背景
+
+`mss-boot` 只有 `.github/copilot-instructions.md`，没有根目录 `AGENTS.md`。对 Codex、Claude、本地 agent 和外部贡献者来说，根目录 agent 指南是低成本、高可见度的协作入口。
+
+## 处理
+
+- 新增 `AGENTS.md`，说明仓库角色、AI 工作规则、验证命令、PR 说明要求、发布兼容约束。
+- 保持 repository-local 记忆继续写入 `aigc/prompts/`。
+
+## 验证
+
+- `git diff --check`
+
+## 后续
+
+其他核心仓库可以按同样结构补齐或对齐 `AGENTS.md`，但要保留各自仓库的验证命令和发布约束。


### PR DESCRIPTION
## Summary
- add root AGENTS.md for AI agents and external contributors
- document repository role, validation commands, PR expectations, and compatibility constraints
- record the decision in repository-local aigc memory

## Tests / 验证
- git diff --check

## Docs / 文档
- Added AGENTS.md
- Added aigc/prompts/agents-guide-2026-06-05.zh-CN.md

## Security / 安全
- Documentation only. No secrets or private endpoints are added.

## Release / 发布与回滚
- No runtime release impact. Rollback is reverting this PR.