### PR TITLE
ci: upgrade action runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -28,8 +28,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:

--- a/.github/workflows/mirror-template.yml
+++ b/.github/workflows/mirror-template.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: 'Mirror to gitee'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: scorecard-results.sarif

--- a/aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md
+++ b/aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md
@@ -1,0 +1,7 @@
+# Actions runtime 升级记忆
+
+- 日期：2026-06-05
+- 背景：后端主干已恢复全绿，但 CodeQL / checkout 仍有 Node.js 20 runtime 与 CodeQL Action v3 的弃用提示。
+- 处理：将后端仓库内的 `actions/checkout` 与 `actions/setup-go` 升级到 `v6`，将 `github/codeql-action/init|analyze|upload-sarif` 升级到 `v4`。
+- 约束：这是 CI 体验与未来兼容性修复，不涉及业务代码、镜像发布或 beta 环境部署。
+- 验证：通过 GitHub API 确认 `checkout@v6` 与 `codeql-action@v4` 标签存在，后续依赖 PR checks 和 main checks 验收。


### PR DESCRIPTION
## Summary
- upgrade checkout/setup-go actions to `v6`
- upgrade CodeQL init/analyze/upload-sarif to `v4`
- record the runtime-upgrade context in `aigc/prompts`

## Tests
- `git diff --check`
- parsed all `.github/workflows/*` files with Ruby YAML
- verified `actions/checkout@v6`, `actions/setup-go@v6`, and `github/codeql-action@v4` tags via GitHub API

## Docs
- Added `aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md`.

## Security
- No backend security behavior changes.
- Keeps CodeQL and SARIF upload actions on the supported major version and moves Go setup to the Node 24-compatible major version.

## Release
- CI-only change; no backend image or beta deployment is triggered by this PR itself.