### PR TITLE
ci: upgrade golangci action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: golangci-lint
         # Advisory until the existing lint backlog is burned down; go test remains required.
         continue-on-error: true
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/aigc/prompts/golangci-action-runtime-upgrade-2026-06-05.zh-CN.md
+++ b/aigc/prompts/golangci-action-runtime-upgrade-2026-06-05.zh-CN.md
@@ -1,0 +1,8 @@
+# golangci-lint action runtime 升级记忆
+
+- 日期：2026-06-05
+- 背景：`actions/setup-go` 等 action 升级到 v6 后，mss-boot 主干 CI 仍提示 `golangci/golangci-lint-action@v8` 使用 Node.js 20 runtime。
+- 处理：将 `golangci/golangci-lint-action` 升级到 `v9`，该版本 action metadata 使用 `node24`。
+- 约束：lint job 仍保持 advisory 模式，历史 lint backlog 不阻断主干；真正必须通过的是 `go test`。
+- 后续：历史 lint annotations 可交给 GitHub Issues / Copilot Code Review / 后续 PR 批量消化，不应让流水线红灯化。
+


### PR DESCRIPTION
## Summary
- upgrade `golangci/golangci-lint-action` from `v8` to `v9`
- keep the lint job advisory while the existing lint backlog is burned down
- record the runtime follow-up in `aigc/prompts`

## Tests
- `git diff --check`
- parsed all `.github/workflows/*` files with Ruby YAML
- verified `golangci/golangci-lint-action@v9` exists and uses `node24` via GitHub API

## Docs
- Added `aigc/prompts/golangci-action-runtime-upgrade-2026-06-05.zh-CN.md`.

## Security
- No backend security behavior changes.
- Removes the remaining Node.js 20 action runtime warning from the lint job.

## Release
- CI-only change; no image publish or beta deployment is triggered by this PR itself.
