### PR TITLE
ci: add Copilot setup steps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
     labels:
       - "area/backend"
       - "type/security"
@@ -19,6 +20,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "area/devops"
       - "type/security"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,28 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Download Go modules
+        run: go mod download

--- a/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md
+++ b/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md
@@ -1,0 +1,20 @@
+# GitHub Copilot Setup Steps
+
+日期：2026-06-05
+
+## 背景
+
+为了把低风险、边界清晰的实现任务更多交给 GitHub Copilot coding agent，
+需要让 GitHub 代理在进入任务前自动准备 Go 环境和依赖缓存。
+
+## 已落地
+
+- 新增 `.github/workflows/copilot-setup-steps.yml`。
+- 工作流只在手动触发、或该 workflow 文件变更时运行。
+- 代理环境步骤包括 checkout、`actions/setup-go@v6` 和 `go mod download`。
+
+## 约束
+
+- 该 workflow 只做环境预热，不替代正式 CI。
+- 正式质量门禁仍以 `ci`、CodeQL、govulncheck、Scorecard、PR Guard 和
+  Docs Drift 为准。


### PR DESCRIPTION
## Summary
- add .github/workflows/copilot-setup-steps.yml so GitHub Copilot coding agent can prewarm Go dependencies
- add explicit Dependabot PR limits and grouped GitHub Actions updates
- record repository-local AIGC memory for the GitHub handoff

## Tests
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'\n- git diff --check\n\n## Docs\n- Adds repository-local AIGC memory under aigc/prompts/.\n\n## Security\n- Keeps the Copilot setup workflow read-only with contents: read.\n- Dependabot grouping only changes version update batching; security alerts remain reviewed through GitHub.\n\n## Release / compatibility / rollback\n- No runtime release impact and no public API compatibility change.\n- Rollback is reverting the setup workflow and Dependabot grouping if they add noise.\n\n## Notes\n- The setup workflow only prepares dependencies; regular CI remains the quality gate.