### PR TITLE
chore: strengthen open source intake and mongo delete validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Report a reproducible defect in mss-boot.
+title: "fix: "
+labels:
+  - bug
+  - needs-triage
+  - area/backend
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve mss-boot. Please do not include secrets,
+        tokens, private URLs, or vulnerability details in a public issue.
+        Security reports should use the repository security policy.
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Which release, branch, or commit are you using?
+      placeholder: "v0.7.2 or main@<sha>"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Runtime, OS, Go version, database, Kubernetes/Istio context, and relevant dependencies.
+      placeholder: "Go 1.26.x, macOS/Linux, MySQL/PostgreSQL, Kubernetes version..."
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest set of steps or code needed to reproduce the issue.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include relevant logs or errors. Redact private values.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is affected, how often it happens, and whether a workaround exists.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/mss-boot-io/mss-boot/security/policy
+    about: Please do not disclose vulnerabilities in public issues.
+  - name: Documentation
+    url: https://docs.mss-boot-io.top
+    about: Check the public documentation before opening a usage question.

--- a/.github/ISSUE_TEMPLATE/docs_request.yml
+++ b/.github/ISSUE_TEMPLATE/docs_request.yml
@@ -1,0 +1,34 @@
+name: Documentation Request
+description: Request clearer docs, examples, or contributor guidance.
+title: "docs: "
+labels:
+  - documentation
+  - area/docs
+  - needs-triage
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page or topic
+      placeholder: "README, quick start, testing, deployment, RBAC..."
+    validations:
+      required: true
+  - type: textarea
+    id: gap
+    attributes:
+      label: What is unclear or missing?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected documentation
+      description: What example, command, explanation, or diagram would help?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Propose a focused mss-boot improvement.
+title: "feat: "
+labels:
+  - enhancement
+  - needs-triage
+  - type/feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What limitation or workflow problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the expected behavior and the smallest useful scope.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Backend/API
+        - Middleware/security
+        - Configuration/deployment
+        - Documentation/examples
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility, migration, or release impact
+      description: Note expected migration, rollback, API, or configuration impact.
+    validations:
+      required: false

--- a/README.Zh-cn.md
+++ b/README.Zh-cn.md
@@ -1,18 +1,22 @@
 # mss-boot
 
 ---
-<img align="right" width="320" src="https://mss-boot-io.github.io/mss-boot-docs/images/logos/logo-b.png"  alt="https://github.com/mss-boot-io/mss-boot"/>
+<img align="right" width="320" src="https://docs.mss-boot-io.top/favicon.ico"  alt="https://github.com/mss-boot-io/mss-boot"/>
 
 
 [![ci](https://github.com/mss-boot-io/mss-boot/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/mss-boot-io/mss-boot/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot/actions/workflows/scorecard.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/scorecard.yml)
 [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot/releases)
-[![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/mss-boot-io/mss-boot)
+[![License](https://img.shields.io/github/license/mss-boot-io/mss-boot.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot/blob/main/LICENSE)
 
 [English](https://github.com/mss-boot-io/mss-boot/blob/main/README.md) | 简体中文
 
 支持grpc、http协议的企业级语言异构微服务解决方案，单服务代码框架坚持极简的原则，同时提供完善的devops流程支撑(gitops)
 
-[在线文档](https://mss-boot-io.github.io/mss-boot-docs/index.html)
+[在线文档](https://docs.mss-boot-io.top)
+
+[贡献指南](./CONTRIBUTING.md) · [安全策略](./SECURITY.md) · [新手任务](https://github.com/mss-boot-io/mss-boot/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
 
 [微服务集合](https://github.com/mss-boot-io/mss-boot-monorepo)
 

--- a/README.Zh-cn.md
+++ b/README.Zh-cn.md
@@ -1,7 +1,7 @@
 # mss-boot
 
 ---
-<img align="right" width="320" src="https://docs.mss-boot-io.top/favicon.ico"  alt="https://github.com/mss-boot-io/mss-boot"/>
+<img align="right" width="32" src="https://docs.mss-boot-io.top/favicon.ico"  alt="https://github.com/mss-boot-io/mss-boot"/>
 
 
 [![ci](https://github.com/mss-boot-io/mss-boot/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ English | [简体中文](https://github.com/mss-boot-io/mss-boot/blob/main/READM
 
 An enterprise-level language heterogeneous microservice solution that supports grpc and http protocols. The single-service code framework adheres to the principle of minimalism, while providing complete devops process support (gitops).
 
-## 📦 Latest Version: v0.7.2
+## 📦 Latest Version: v0.7.1
 
 [documentation](https://docs.mss-boot-io.top)
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 
 
 [![ci](https://github.com/mss-boot-io/mss-boot/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/mss-boot-io/mss-boot/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot/actions/workflows/scorecard.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/scorecard.yml)
 [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot/releases)
-[![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/mss-boot-io/mss-boot)
+[![License](https://img.shields.io/github/license/mss-boot-io/mss-boot.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot/blob/main/LICENSE)
 
 English | [简体中文](https://github.com/mss-boot-io/mss-boot/blob/main/README.Zh-cn.md)
 
@@ -14,9 +16,11 @@ English | [简体中文](https://github.com/mss-boot-io/mss-boot/blob/main/READM
 
 An enterprise-level language heterogeneous microservice solution that supports grpc and http protocols. The single-service code framework adheres to the principle of minimalism, while providing complete devops process support (gitops).
 
-## 📦 Latest Version: v0.7.1
+## 📦 Latest Version: v0.7.2
 
 [documentation](https://docs.mss-boot-io.top)
+
+[contributing](./CONTRIBUTING.md) · [security](./SECURITY.md) · [good first issues](https://github.com/mss-boot-io/mss-boot/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
 
 [http service template](https://github.com/mss-boot-io/service-http)
 

--- a/pkg/response/actions/mgm/delete.go
+++ b/pkg/response/actions/mgm/delete.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/kamva/mgm/v3"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/mss-boot-io/mss-boot/pkg/response"
@@ -64,7 +65,13 @@ func (e *Delete) delete(c *gin.Context, ids ...string) {
 		api.OK(nil)
 		return
 	}
-	_, err := mgm.Coll(e.Model).DeleteMany(c, bson.M{"_id": bson.M{"$in": ids}})
+	objectIDs, err := parseObjectIDs(ids)
+	if err != nil {
+		api.AddError(err)
+		api.Err(http.StatusUnprocessableEntity)
+		return
+	}
+	_, err = mgm.Coll(e.Model).DeleteMany(c, bson.M{"_id": bson.M{"$in": objectIDs}})
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			api.OK(nil)
@@ -74,4 +81,16 @@ func (e *Delete) delete(c *gin.Context, ids ...string) {
 		return
 	}
 	api.OK(nil)
+}
+
+func parseObjectIDs(ids []string) ([]primitive.ObjectID, error) {
+	objectIDs := make([]primitive.ObjectID, 0, len(ids))
+	for _, id := range ids {
+		objectID, err := primitive.ObjectIDFromHex(id)
+		if err != nil {
+			return nil, err
+		}
+		objectIDs = append(objectIDs, objectID)
+	}
+	return objectIDs, nil
 }

--- a/pkg/response/actions/mgm/delete_test.go
+++ b/pkg/response/actions/mgm/delete_test.go
@@ -1,0 +1,24 @@
+package mgm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseObjectIDs(t *testing.T) {
+	ids, err := parseObjectIDs([]string{
+		"507f1f77bcf86cd799439011",
+		"507f1f77bcf86cd799439012",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+}
+
+func TestParseObjectIDsRejectsInvalidID(t *testing.T) {
+	ids, err := parseObjectIDs([]string{"507f1f77bcf86cd799439011", "not-an-object-id"})
+
+	require.Error(t, err)
+	require.Nil(t, ids)
+}


### PR DESCRIPTION
## Summary

- Add structured issue forms for bug reports, feature requests, and documentation requests.
- Update README badges, latest version, documentation domain, and contributor/security entry points.
- Validate Mongo delete IDs as ObjectID values before building the delete query.

## Tests / Verification

- Parsed all issue template YAML files with Ruby YAML loader.
- Ran ok  	github.com/mss-boot-io/mss-boot/pkg/response/actions/mgm	(cached).

## Docs Impact

- README and issue intake templates updated.
- No public API documentation content changed.

## Security Impact

- Reduces Mongo delete query risk by rejecting invalid external IDs before querying.
- Adds clearer public security reporting entry points.

## Release Impact

- No migration, API compatibility, image, or rollback impact expected.
- Invalid Mongo delete IDs now return 422 instead of reaching the delete query.