### PR TITLE
fix: keep query cache invalidation complete

### DIFF
--- a/aigc/README.md
+++ b/aigc/README.md
@@ -22,3 +22,4 @@
 ## 参考文件
 
 - 详细约束见：`aigc/prompts/prompt-constraints.zh-CN.md`
+- Query cache tag invalidation：`aigc/prompts/query-cache-tag-invalidation-2026-06-07.zh-CN.md`

--- a/aigc/prompts/query-cache-tag-invalidation-2026-06-07.zh-CN.md
+++ b/aigc/prompts/query-cache-tag-invalidation-2026-06-07.zh-CN.md
@@ -1,0 +1,50 @@
+# Query Cache Tag Invalidation
+
+日期：2026-06-07
+
+## 背景
+
+`mss-boot-admin#105` 反馈启用 `cache.queryCache` 后，数据更新后详情/编辑接口可能读到旧缓存。
+admin PR `mss-boot-admin#371` 已接入 query cache 初始化和 table tag 清理，但社区 review
+指出核心层仍有两个缺口：
+
+- Redis query cache 只在缓存命中时把 key 加入 tag set；首次 cache miss 后写入的新缓存
+  没有关联到 `gorm.cache:<table>`，后续 `RemoveFromTag` 可能清不到它。
+- GORM create action 成功后没有触发 `CleanCacheFromTag(table)`，已有 list/search 缓存会
+  等 TTL 才刷新。
+
+## 决策
+
+- query cache miss 后成功 `SaveCache` 时，也必须调用 `SaveTagKey(ctx, tag, key)`。
+- `RemoveFromTag` 删除被 tag 关联的 cache keys 后，也删除 tag set 本身；空 tag set
+  应安全返回，不发出无 key 的 Redis DEL。
+- GORM create action 成功提交事务后，调用 `CleanCacheFromTag(c, m.TableName())`，与
+  update/delete 的缓存失效语义保持一致。
+- 不改变公开 API；本次不处理 `Cache.Init` callback 显式传 adapter 这类较大 API 优化。
+
+## 本轮变更
+
+- `pkg/config/storage/cache/redis.go`
+  - cache miss 保存缓存后写入 tag set。
+  - `RemoveFromTag` 同时删除缓存 key 和 tag set，空集合安全处理。
+- `pkg/response/actions/gorm/control.go`
+  - create 成功后清理 table tag。
+- `pkg/config/storage/cache/redis_test.go`
+  - 使用 `miniredis` 覆盖首次查询写入缓存后 tag set 包含 key。
+  - 覆盖 `RemoveFromTag` 删除 key 和 tag set。
+- `pkg/response/actions/gorm/control_test.go`
+  - 使用 Gin + SQLite 覆盖 create action 成功后调用 `CleanCacheFromTag`。
+
+## 验证
+
+```text
+go test ./pkg/config/storage/cache ./pkg/response/actions/gorm
+go test ./...
+```
+
+## 后续
+
+- admin PR `mss-boot-admin#371` 合并前需要使用包含本修复的 mss-boot 版本或 pseudo-version
+  构建候选镜像，并在 `mss-boot-dev` 验证 create/update/delete 后 get/list 不返回旧缓存。
+- 若后续要消除 `Cache.Init(set, queryCache)` 的隐式顺序契约，可以单独设计 API：
+  让 queryCache callback 显式接收已初始化的 cache adapter。

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/andygrunwald/go-jira v1.17.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 // indirect
@@ -204,6 +205,7 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andygrunwald/go-jira v1.17.0 h1:bbu5H676l6MaNcV6A7VDIAjIOQVgzNGEhNAwNI/Cjgo=
 github.com/andygrunwald/go-jira v1.17.0/go.mod h1:tiZsPUu9824bwcI2BUXatE4hJbs9rUOif0nv1lkq1hQ=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
@@ -599,6 +601,8 @@ github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7Jul
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=

--- a/pkg/config/storage/cache/redis.go
+++ b/pkg/config/storage/cache/redis.go
@@ -103,6 +103,7 @@ func (r *Redis) Query(tx *gorm.DB) {
 		tx.Logger.Error(ctx, err.Error())
 		return
 	}
+	_ = r.SaveTagKey(ctx, tag, key)
 }
 
 func (r *Redis) QueryCache(ctx context.Context, key string, dest any) error {
@@ -137,6 +138,10 @@ func (r *Redis) RemoveFromTag(ctx context.Context, tag string) error {
 	if err != nil {
 		return err
 	}
+	if len(keys) == 0 {
+		return r.Del(ctx, tag).Err()
+	}
+	keys = append(keys, tag)
 	return r.Del(ctx, keys...).Err()
 }
 

--- a/pkg/config/storage/cache/redis_test.go
+++ b/pkg/config/storage/cache/redis_test.go
@@ -5,8 +5,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/glebarez/sqlite"
 	"github.com/redis/go-redis/v9"
+	"gorm.io/gorm"
 )
+
+type queryCacheRecord struct {
+	ID   int64
+	Name string
+}
 
 func testRedisClient(t *testing.T) redis.UniversalClient {
 	t.Helper()
@@ -27,6 +35,80 @@ func testRedisClient(t *testing.T) redis.UniversalClient {
 		_ = client.Close()
 	})
 	return client
+}
+
+func testMiniredisClient(t *testing.T) (redis.UniversalClient, *miniredis.Miniredis) {
+	t.Helper()
+	server := miniredis.RunT(t)
+	client := redis.NewUniversalClient(&redis.UniversalOptions{
+		Addrs: []string{server.Addr()},
+	})
+	t.Cleanup(func() {
+		_ = client.Close()
+		server.Close()
+	})
+	return client, server
+}
+
+func TestRedis_QueryStoresNewCacheKeyInTagSet(t *testing.T) {
+	client, _ := testMiniredisClient(t)
+	r, err := NewRedis(client, nil, WithQueryCacheKeys("*"), WithQueryCacheDuration(time.Minute))
+	if err != nil {
+		t.Fatalf("new redis cache: %v", err)
+	}
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	if err := db.AutoMigrate(&queryCacheRecord{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+	if err := db.Create(&queryCacheRecord{Name: "acme"}).Error; err != nil {
+		t.Fatalf("seed record: %v", err)
+	}
+	if err := r.Initialize(db); err != nil {
+		t.Fatalf("initialize query cache: %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), "gorm:cache:tag", "query_cache_records")
+	var records []queryCacheRecord
+	if err := db.WithContext(ctx).Find(&records).Error; err != nil {
+		t.Fatalf("query records: %v", err)
+	}
+	if len(records) != 1 || records[0].Name != "acme" {
+		t.Fatalf("expected seeded record, got %#v", records)
+	}
+
+	tag := "gorm.cache:query_cache_records"
+	keys, err := client.SMembers(context.Background(), tag).Result()
+	if err != nil {
+		t.Fatalf("read tag set: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected one cached key in tag set, got %d: %#v", len(keys), keys)
+	}
+	if exists, err := client.Exists(context.Background(), keys[0]).Result(); err != nil || exists != 1 {
+		t.Fatalf("expected cached key to exist, exists=%d err=%v", exists, err)
+	}
+
+	if err := r.RemoveFromTag(context.Background(), tag); err != nil {
+		t.Fatalf("remove from tag: %v", err)
+	}
+	if exists, err := client.Exists(context.Background(), keys[0], tag).Result(); err != nil || exists != 0 {
+		t.Fatalf("expected cached key and tag set to be removed, exists=%d err=%v", exists, err)
+	}
+}
+
+func TestRedis_RemoveFromTagHandlesEmptyTag(t *testing.T) {
+	client, _ := testMiniredisClient(t)
+	r, err := NewRedis(client, nil)
+	if err != nil {
+		t.Fatalf("new redis cache: %v", err)
+	}
+
+	if err := r.RemoveFromTag(context.Background(), "gorm.cache:missing"); err != nil {
+		t.Fatalf("remove missing tag: %v", err)
+	}
 }
 
 func TestRedis_HashSet(t *testing.T) {

--- a/pkg/response/actions/gorm/control.go
+++ b/pkg/response/actions/gorm/control.go
@@ -122,6 +122,9 @@ func (e *Control) create(c *gin.Context) {
 		return
 	}
 
+	if CleanCacheFromTag != nil {
+		_ = CleanCacheFromTag(c, m.TableName())
+	}
 	api.OK(m)
 }
 

--- a/pkg/response/actions/gorm/control_test.go
+++ b/pkg/response/actions/gorm/control_test.go
@@ -1,0 +1,67 @@
+package gorm
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/mss-boot-io/mss-boot/pkg/config/gormdb"
+	"gorm.io/gorm"
+)
+
+type createCacheRecord struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+func (*createCacheRecord) TableName() string {
+	return "create_cache_records"
+}
+
+func TestControlCreateCleansQueryCacheTag(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	if err := db.AutoMigrate(&createCacheRecord{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	previousDB := gormdb.DB
+	gormdb.DB = db
+	defer func() {
+		gormdb.DB = previousDB
+	}()
+
+	previousCleaner := CleanCacheFromTag
+	var cleanedTag string
+	CleanCacheFromTag = func(_ context.Context, tag string) error {
+		cleanedTag = tag
+		return nil
+	}
+	defer func() {
+		CleanCacheFromTag = previousCleaner
+	}()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	control := NewControl(WithModel(&createCacheRecord{}))
+	router.POST("/records", control.Handler()...)
+
+	req := httptest.NewRequest(http.MethodPost, "/records", bytes.NewBufferString(`{"name":"acme"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK && resp.Code != http.StatusCreated {
+		t.Fatalf("expected successful response, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if cleanedTag != "create_cache_records" {
+		t.Fatalf("expected create to clean table cache tag, got %q", cleanedTag)
+	}
+}


### PR DESCRIPTION
## Summary

- Records query-cache keys in the table tag set after a cache miss is saved, not only after cache hits.
- Deletes the tag set together with tagged cache keys during `RemoveFromTag`.
- Clears the table query-cache tag after successful create actions so list/search cache entries do not remain stale after inserts.
- Adds miniredis-backed coverage for tag-set behavior and a Gin/GORM create-action regression test.

## Related admin work

This supports `mss-boot-admin` PR mss-boot-io/mss-boot-admin#371 for issue mss-boot-io/mss-boot-admin#105. The admin PR wires query-cache initialization and table-tag cleanup; this core PR makes the tag set complete and invalidates create-side list/search cache as well.

## Tests

```text
go test ./pkg/config/storage/cache ./pkg/response/actions/gorm
go test ./...
```

## Docs

AI memory was added at `aigc/prompts/query-cache-tag-invalidation-2026-06-07.zh-CN.md`, and `aigc/README.md` links to the new memory entry.

## Security

This change only affects query-cache freshness and tag invalidation. It does not change authentication, authorization, RBAC policy decisions, secrets handling, or data exposure rules.

## Release

No migration is required. Applications already using query cache get more complete tag invalidation behavior after upgrading the module. Rollback is to return to the previous mss-boot module version.