### PR TITLE
ci: make release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,24 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Get version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+      - name: Upsert release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-      - name: Release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-          prerelease: false
+          tag="${GITHUB_REF_NAME}"
+          title="mss-boot ${tag}"
+
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            gh release edit "${tag}" \
+              --title "${title}" \
+              --draft=false \
+              --prerelease=false
+          else
+            gh release create "${tag}" \
+              --verify-tag \
+              --generate-notes \
+              --title "${title}"
+          fi

--- a/aigc/prompts/release-upsert-workflow-2026-06-09.zh-CN.md
+++ b/aigc/prompts/release-upsert-workflow-2026-06-09.zh-CN.md
@@ -1,0 +1,30 @@
+# mss-boot release upsert 工作流记录
+
+## 背景
+
+- 记录时间：2026-06-09
+- 影响文件：`.github/workflows/release.yml`
+- 触发场景：推送 `v*.*.*` tag 自动发布 GitHub Release。
+
+## 问题
+
+`v0.7.3` 的 Release 实际已经创建成功，但 workflow 最后因重复创建同 tag release 报红：
+
+```text
+Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
+```
+
+这会让公开 Actions 页面看起来像版本发布失败，影响开源项目可信度。
+
+## 修复
+
+- 不再直接使用 `softprops/action-gh-release` 创建 release。
+- 改为 `gh release view` 判断 release 是否已存在。
+- 已存在时执行 `gh release edit`，确保标题、draft、prerelease 状态正确。
+- 不存在时执行 `gh release create --verify-tag --generate-notes`。
+- release step 设置 `GH_REPO=${{ github.repository }}`，避免未 checkout 时 `gh` 无法定位仓库或误用其它 remote。
+
+## 验证
+
+- workflow YAML 通过 `git diff --check`。
+- 后续新 tag 或重复触发 tag workflow 时，release 创建应具备幂等性。


### PR DESCRIPTION
## Summary

- make the tag release workflow idempotent with `gh release view/create/edit`
- avoid public red Actions runs when a release already exists for the tag
- record the release workflow decision in repository-local `aigc` memory

## Tests / Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`
- `git diff --check`

## Docs Impact

- Added `aigc/prompts/release-upsert-workflow-2026-06-09.zh-CN.md` to record the release workflow decision and the `v0.7.3` duplicate-tag failure pattern.

## Security Impact

- No secret handling or runtime permissions were expanded.
- The workflow continues to use the built-in `GITHUB_TOKEN` with `contents: write` only for GitHub Release create/edit operations.

## Release / Compatibility / Rollback Impact

- Tag release behavior becomes idempotent: existing releases are edited, missing releases are created with generated notes.
- No Go package code or module compatibility changes.
- Rollback path: revert this workflow change to restore the previous `softprops/action-gh-release` behavior.