### PR TITLE
ci: block new golangci-lint issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   test:
@@ -38,8 +39,18 @@ jobs:
           go get -u golang.org/x/tools/cmd/goimports
           go install golang.org/x/tools/cmd/goimports
 
-      - name: golangci-lint
-        # Advisory until the existing lint backlog is burned down; go test remains required.
+      - name: golangci-lint new issues
+        if: github.event_name == 'pull_request'
+        uses: golangci/golangci-lint-action@v9
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+          # 只扫秒当前目录
+          working-directory: ${{ github.workspace }}
+          only-new-issues: true
+#          args: "run -v ./..."
+      - name: golangci-lint baseline advisory
+        if: github.event_name != 'pull_request'
         continue-on-error: true
         uses: golangci/golangci-lint-action@v9
         with:

--- a/aigc/prompts/required-golangci-lint-2026-06-09.zh-CN.md
+++ b/aigc/prompts/required-golangci-lint-2026-06-09.zh-CN.md
@@ -1,0 +1,28 @@
+# golangci-lint 新增问题门禁记忆
+
+- 日期：2026-06-09
+- 仓库：mss-boot
+- 关联 Issue：#352
+
+## 背景
+
+早期开源治理时，`golangci-lint` 因历史 backlog 先以 advisory 方式运行，workflow 使用 `continue-on-error: true`，避免未清理完的 lint 债阻塞贡献。
+
+## 当前证据
+
+- 最新 main CI run `27155421788` 的 `lint` job 显示 success，但这是 `continue-on-error` 掩盖后的 job 结果。
+- 去掉 advisory 后，PR #383 暴露当前全量 lint 仍有 131 个历史问题。
+- main 分支保护已把 `lint` 作为 required check。
+
+## 决策
+
+- PR 场景使用 `golangci/golangci-lint-action@v9` 的 `only-new-issues: true`，阻断新增 lint 债。
+- main push 场景继续保留全量 baseline advisory，避免历史 131 个问题导致 main push 全红。
+- #352 不关闭，继续作为全量清理 backlog 的长期小任务。
+- PR 正文应包含 tests/docs/security/release impact，并说明不会关闭 #352。
+
+## 验证
+
+- 本地执行 `git diff --check`。
+- 本地执行 `go test ./...`。
+- GitHub PR CI 需要重新验证 `test` 与 `lint` 均为 success；其中 `lint` 应只阻断本 PR 新增问题。


### PR DESCRIPTION
## Summary
- Split golangci-lint enforcement into two paths.
- Pull requests now run `golangci-lint` with `only-new-issues: true`, so new lint debt is blocking.
- Main pushes keep the full baseline lint run advisory while the existing 131 historical issues are burned down under #352.
- Record the decision in repository-local AIGC memory.

This does not close #352; it makes #352 safer to complete incrementally.

## Tests
- `git diff --check`
- `go test ./...`
- workflow YAML parse for `.github/workflows/ci.yml`
- Verified the first full blocking attempt exposed the existing 131-issue baseline, so this PR was adjusted to block only new PR issues.

## Docs
- Added `aigc/prompts/required-golangci-lint-2026-06-09.zh-CN.md`.

## Security
- No secret or authentication behavior changed.
- This strengthens PR enforcement by preventing new lint findings from being introduced.

## Release / Compatibility
- No runtime compatibility change.
- Release flow is unaffected; only CI enforcement behavior changes.