### PR TITLE
docs: document test workflow and action glossary

### DIFF
--- a/README.Zh-cn.md
+++ b/README.Zh-cn.md
@@ -34,6 +34,47 @@
 > - [ ] 支持istio链路追踪
 > - [ ] 开箱即用支持
 
+## 🧭 Action/Controller 术语
+
+mss-boot 的请求流程会反复出现以下概念：
+
+- **Controller**：实现 `pkg/response.Controller` 的控制器，负责路由路径、路由级 Gin handlers，以及按 action 名称取得具体 `Action`。`pkg/response/controller.Simple` 会根据 GORM、MGM 或 Kubernetes 模型 provider 选择对应 action。
+- **Action**：`get`、`search`、`control`、`delete` 等具名请求动作。Action 实现 `response.Action`，返回 Gin handler chain，并封装该动作在具体 provider 下的处理逻辑。
+- **Hook**：挂在生命周期节点上的回调，例如 `BeforeCreate`、`AfterUpdate`、`BeforeSearch`，配置源的 `PrefixHook` / `PostHook`，以及服务启动或关闭回调。
+- **Scope**：通常通过 `WithScope` 注入的按请求查询过滤器，会把当前 Gin context 和模型表转换成 GORM scope。常用于租户、归属关系或其他上下文约束。
+- **Provider**：用于选择后端实现的枚举或 `Stringer`。控制器常见的是 `ModelProviderGorm`、`ModelProviderMgm`、`ModelProviderK8S`；配置源与存储包也有各自的 provider。
+
+## 🧪 本地验证
+
+提交 PR 前建议先在仓库根目录运行：
+
+```bash
+# 必须通过的本地测试入口
+go test ./...
+
+# 覆盖率报告
+go test ./... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+
+# 集成测试，需要先配置对应外部服务
+go test -tags=integration ./...
+```
+
+依赖数据库、对象存储、Kubernetes、云凭证或其他可选外部服务的集成类测试，在配置缺失时应主动 skip，而不是让普通本地验证失败。
+
+Lint 流程与 CI 保持一致：
+
+```bash
+# 未安装工具时先安装
+go install golang.org/x/tools/cmd/goimports@latest
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+
+# 本地 lint 扫描
+golangci-lint run ./...
+```
+
+GitHub Actions 会在仓库根目录运行 action 提供的 latest `golangci-lint`。如果本地二进制由低于 `go.mod` 目标版本的 Go 构建，请先重新安装再扫描。当前 lint job 用于提示历史 lint backlog，`go test ./...` 仍是必须通过的 CI 检查。
+
 ## 请我喝杯咖啡
 <a href="https://www.buymeacoffee.com/lwnmengjing" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ An enterprise-level language heterogeneous microservice solution that supports g
 - **API Reference**: Complete Swagger documentation for all endpoints
 - **Migration Guides**: Clear upgrade paths from previous versions
 
+## 🧭 Action/Controller Glossary
+
+The request flow uses a small set of repeated terms:
+
+- **Controller**: A `pkg/response.Controller` implementation that owns a route path, route-level Gin handlers, and the mapping from an action name to a concrete `Action`. `pkg/response/controller.Simple` chooses provider-specific actions for GORM, MGM, or Kubernetes models.
+- **Action**: A named request operation such as `get`, `search`, `control`, or `delete`. An action implements `response.Action`, returns a Gin handler chain, and contains the provider-specific logic for handling that operation.
+- **Hook**: A callback attached to a lifecycle point. Common examples are `BeforeCreate`, `AfterUpdate`, `BeforeSearch`, config source `PrefixHook` / `PostHook`, and server start or shutdown hooks.
+- **Scope**: A per-request query filter, usually supplied through `WithScope`, that turns the current Gin context and model table into a GORM scope. Use scopes for tenant filters, ownership filters, or other contextual constraints.
+- **Provider**: The selected backend implementation for a model, config source, or storage target. For controllers this is usually `ModelProviderGorm`, `ModelProviderMgm`, or `ModelProviderK8S`; config and storage packages have their own provider enums.
+
 ## 📋 Todo List
 > - [x] Support dynamodb
 > - [x] Support config provider  
@@ -82,16 +92,30 @@ The project follows strict testing requirements:
 
 ### Running Tests
 ```bash
-# Unit tests
-go test ./... -v
+# Required local test gate
+go test ./...
 
 # Coverage report
 go test ./... -coverprofile=coverage.out
 go tool cover -func=coverage.out
 
-# Integration tests (requires database)
+# Integration tests (requires configured external services)
 go test -tags=integration ./...
 ```
+
+Integration-style tests should skip when optional databases, object storage, Kubernetes clusters, cloud credentials, or other external services are not configured.
+
+### Running Lint
+```bash
+# Install the tools used by the CI lint job when they are not already available
+go install golang.org/x/tools/cmd/goimports@latest
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+
+# Local lint sweep
+golangci-lint run ./...
+```
+
+The GitHub Actions lint job runs `golangci-lint` from the repository root with the latest action-provided version. If a local binary was built with an older Go version than `go.mod` targets, reinstall it before running the sweep. The lint job is currently advisory while the existing lint backlog is reduced; `go test ./...` remains the required CI gate.
 
 ## 🔧 Quick Start
 

--- a/aigc/README.md
+++ b/aigc/README.md
@@ -23,3 +23,4 @@
 
 - 详细约束见：`aigc/prompts/prompt-constraints.zh-CN.md`
 - Query cache tag invalidation：`aigc/prompts/query-cache-tag-invalidation-2026-06-07.zh-CN.md`
+- README 本地验证与 Action/Controller 术语：`aigc/prompts/readme-test-lint-action-glossary-2026-06-09.zh-CN.md`

--- a/aigc/prompts/readme-test-lint-action-glossary-2026-06-09.zh-CN.md
+++ b/aigc/prompts/readme-test-lint-action-glossary-2026-06-09.zh-CN.md
@@ -1,0 +1,25 @@
+# README 本地验证与 Action/Controller 术语记忆
+
+- 日期：2026-06-09
+- 关联 issue：#348、#349
+- 变更范围：仅更新 `README.md`、`README.Zh-cn.md` 与 `aigc/` 记忆文件；不改 Go 业务代码、不改 CI 行为。
+
+## 本地验证口径
+
+- README 需要明确 `go test ./...` 是本地与 CI 的必过测试入口。
+- Lint 文档对齐 `.github/workflows/ci.yml`：CI 使用 `golangci/golangci-lint-action@v9`、`version: latest`，在仓库根目录运行 `golangci-lint`；本地可用 `golangci-lint run ./...` 复现，安装命令使用 v2 模块路径 `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`。
+- CI lint job 仍是 advisory，用于提示历史 lint backlog；不要把文档写成 lint 必须全绿才可合并。
+- 依赖数据库、对象存储、Kubernetes、云凭证等可选外部服务的集成类测试，在配置缺失时应 skip，避免给普通本地验证增加新服务要求。
+
+## 术语表口径
+
+- `Controller`：`pkg/response.Controller`，负责 route path、Gin handlers、按名称返回 `Action`，并暴露 `GetProvider()`。
+- `Action`：`response.Action`，包含 `String()` 和 `Handler() gin.HandlersChain`；常见名称来自 `pkg/response/action.go`，如 `get`、`search`、`control`、`delete`。
+- `Hook`：生命周期回调，包括 GORM/K8S actions 的 before/after hooks、配置源 `PrefixHook` / `PostHook`、server start/end hooks。
+- `Scope`：请求上下文相关的查询过滤器，主要是 `WithScope` 提供的 GORM scope，也包括 virtual model 中的 table/tenant/URI/search/pagination scopes。
+- `Provider`：选择后端实现的枚举或 `Stringer`，如 `ModelProviderGorm`、`ModelProviderMgm`、`ModelProviderK8S`，以及配置源/存储包里的 provider。
+
+## 后续维护提醒
+
+- 如果 CI 从 advisory lint 改成 required，README 中的 lint 状态说明需要同步更新。
+- 如果新增 `create` / `update` 等默认 controller action，术语表中的示例 action 名称可以补齐。


### PR DESCRIPTION
## Summary
- Add a concise Action/Controller glossary covering Controller, Action, Hook, Scope, and Provider.
- Document the local `go test ./...` workflow and the repository lint command in both English and Chinese READMEs.
- Add AIGC memory for the README test/lint and glossary maintenance context.

Closes #348
Closes #349

## Documentation Impact
- Updates `README.md` and `README.Zh-cn.md` with contributor-facing verification guidance.
- Records the issue scope and future maintenance notes in `aigc/prompts/readme-test-lint-action-glossary-2026-06-09.zh-CN.md`.

## Security Notes
- Documentation-only change; no runtime behavior, dependencies, credentials, permissions, or CI enforcement changed.
- Notes that optional external-service tests should skip when credentials or services are not configured.

## Tests Impact
- No Go source or test files changed.
- `go test ./...` passes.
- Lint remains advisory per the existing CI workflow; the latest golangci-lint run reports the existing repository lint backlog.

## Verification
- `git diff --check`
- `go test ./...`
- `golangci-lint run ./...` with the installed local binary could not load config because it was built with Go 1.25 while `go.mod` targets Go 1.26.0.
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...` completed and reported 131 existing Go lint issues outside this docs-only change.

## Release Safety
- Documentation-only change; no config migration, deployment order change, compatibility impact, rollback requirement, or release note needed.
