### PR TITLE
test: cover config env fallback

### DIFF
--- a/aigc/prompts/config-env-fallback-test-2026-06-09.zh-CN.md
+++ b/aigc/prompts/config-env-fallback-test-2026-06-09.zh-CN.md
@@ -1,0 +1,25 @@
+# config env template fallback 测试记忆
+
+## 背景
+
+- 时间：2026-06-09
+- 仓库：`mss-boot`
+- 关联 issue：`mss-boot-io/mss-boot#350`
+- 目标：为配置模板中的环境变量 fallback 行为补充小范围、可复现、无外部依赖的测试。
+
+## 实施
+
+- 在 `pkg/config/config_test.go` 中补充表驱动测试。
+- 覆盖缺失变量渲染为空字符串、精确命中、小写 key fallback 到大写环境变量、大写 key fallback 到小写环境变量。
+- 补充 `getValueFromEnv` 的 map 结果断言，保证非 `.Env.*` 解析键不会污染环境变量映射。
+
+## 验证
+
+- `go test ./pkg/config`
+- `go test ./...`
+
+## 约束
+
+- 不修改配置解析语义。
+- 不引入网络、数据库、Redis、对象存储或外部凭据依赖。
+- 该改动属于社区 good-first-issue 的测试覆盖收敛，应保持 PR 小而清晰。

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"fmt"
+	"os"
 	"testing"
 )
 
@@ -36,7 +36,92 @@ func Test_parseTemplateWithEnv(t *testing.T) {
 				t.Errorf("parseTemplateWithEnv() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			fmt.Println(string(got))
+			_ = got
 		})
+	}
+}
+
+func Test_parseTemplateWithEnvFallback(t *testing.T) {
+	t.Setenv("MSS_BOOT_EXACT", "exact-value")
+	t.Setenv("MSS_BOOT_UPPER", "upper-value")
+	t.Setenv("mss_boot_lower", "lower-value")
+
+	tests := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{
+			name:     "missing env renders empty string",
+			template: `value: "{{.Env.MSS_BOOT_MISSING}}"`,
+			want:     `value: ""`,
+		},
+		{
+			name:     "exact env key wins",
+			template: `value: "{{.Env.MSS_BOOT_EXACT}}"`,
+			want:     `value: "exact-value"`,
+		},
+		{
+			name:     "uppercase fallback is supported",
+			template: `value: "{{.Env.mss_boot_upper}}"`,
+			want:     `value: "upper-value"`,
+		},
+		{
+			name:     "lowercase fallback is supported",
+			template: `value: "{{.Env.MSS_BOOT_LOWER}}"`,
+			want:     `value: "lower-value"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTemplateWithEnv([]byte(tt.template))
+			if err != nil {
+				t.Fatalf("parseTemplateWithEnv() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("parseTemplateWithEnv() = %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func Test_getValueFromEnvFallbackMap(t *testing.T) {
+	t.Setenv("MSS_BOOT_DIRECT", "direct-value")
+	t.Setenv("MSS_BOOT_FROM_UPPER", "upper-value")
+	t.Setenv("mss_boot_from_lower", "lower-value")
+	if err := os.Unsetenv("MSS_BOOT_ABSENT"); err != nil {
+		t.Fatalf("Unsetenv() error = %v", err)
+	}
+
+	got := getValueFromEnv([]string{
+		"Env.MSS_BOOT_DIRECT",
+		"Env.mss_boot_from_upper",
+		"Env.MSS_BOOT_FROM_LOWER",
+		"Env.MSS_BOOT_ABSENT",
+		"Other.IGNORED",
+	})
+	data, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("getValueFromEnv() = %T, want map[string]any", got)
+	}
+	env, ok := data["Env"].(map[string]string)
+	if !ok {
+		t.Fatalf("getValueFromEnv()[Env] = %T, want map[string]string", data["Env"])
+	}
+
+	assertEnvValue(t, env, "MSS_BOOT_DIRECT", "direct-value")
+	assertEnvValue(t, env, "mss_boot_from_upper", "upper-value")
+	assertEnvValue(t, env, "MSS_BOOT_FROM_LOWER", "lower-value")
+	assertEnvValue(t, env, "MSS_BOOT_ABSENT", "")
+	if _, exists := env["IGNORED"]; exists {
+		t.Fatalf("non Env key should be ignored")
+	}
+}
+
+func assertEnvValue(t *testing.T, env map[string]string, key, want string) {
+	t.Helper()
+	if got := env[key]; got != want {
+		t.Fatalf("env[%q] = %q, want %q", key, got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- add table-driven coverage for config template environment fallback behavior
- cover missing variables, exact lookup, uppercase fallback, lowercase fallback, and ignored non-Env parse keys
- record AIGC memory for the community issue follow-up

Closes #350

## Documentation Impact
- adds `aigc/prompts/config-env-fallback-test-2026-06-09.zh-CN.md` to preserve the issue scope and validation notes
- no public README or API documentation changes are required because this is test coverage for existing behavior

## Security Notes
- no config semantics, credentials, network calls, database, Redis, object storage, authentication, or authorization behavior changed
- the tests use isolated `t.Setenv` values only

## Tests Impact
- adds deterministic config package tests with no external service dependency
- keeps current fallback semantics unchanged

## Verification
- `go test ./pkg/config`
- `go test ./...`
- `git diff --check`

## Release Safety
- test-only change; no config migration, deployment order change, compatibility impact, rollback requirement, or release note needed
